### PR TITLE
fix: handle messages with missing role key

### DIFF
--- a/resources/views/livewire/chat-bubble-component.blade.php
+++ b/resources/views/livewire/chat-bubble-component.blade.php
@@ -135,6 +135,7 @@
                             </div>
 
                             @foreach (array_reverse($messages) as $msg)
+                                @continue(empty($msg['role']))
                                 @if ($msg['role'] === 'user')
                                     <div class="flex justify-end">
                                         <div

--- a/src/Livewire/ChatBubbleComponent.php
+++ b/src/Livewire/ChatBubbleComponent.php
@@ -150,14 +150,16 @@ class ChatBubbleComponent extends Component
 
     private function messagesToPrism(array $messages): array
     {
-        return collect($messages)->map(function ($message) {
-            return match ($message['role']) {
-                'user' => new UserMessage($message['parts']['text'] ?? ''),
-                'assistant' => new AssistantMessage($message['parts']['text'] ?? '', $message['parts']['tool_calls'] ?? []),
-                'tool_result' => new ToolResultMessage($message['parts']['tool_results'] ?? []),
-                default => throw new \InvalidArgumentException('Unknown message role: '.$message['role']),
-            };
-        })->all();
+        return collect($messages)
+            ->filter(fn ($message) => isset($message['role']))
+            ->map(function ($message) {
+                return match ($message['role']) {
+                    'user' => new UserMessage($message['parts']['text'] ?? ''),
+                    'assistant' => new AssistantMessage($message['parts']['text'] ?? '', $message['parts']['tool_calls'] ?? []),
+                    'tool_result' => new ToolResultMessage($message['parts']['tool_results'] ?? []),
+                    default => throw new \InvalidArgumentException('Unknown message role: '.$message['role']),
+                };
+            })->all();
     }
 
     public function resetChat(): void


### PR DESCRIPTION
## Summary
- Skip messages without a `role` key in the Blade `@foreach` loop using `@continue(empty($msg['role']))`
- Filter out messages without a `role` key in `messagesToPrism()` before mapping

## Problem
Messages stored in session via Livewire's `#[Session]` attribute can lose their `role` key (e.g., due to session corruption or deserialization issues), causing an `Undefined array key "role"` ViewException.

Sentry: [INNO-BRAIN-DE-1H](https://sentry.innobra.in/organizations/innobrain/issues/2394/?referrer=github_integration)

## Test plan
- [x] `pint --test` passes
- [ ] Verify chat bubble works normally with valid messages
- [ ] Verify no crash when session contains a message without `role` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)